### PR TITLE
Add param for configuring the date format of posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ math = true # for introducing $KaTEX$
 env = "production" # for Google Analytics and DISQUS.
 useChineseFonts = true # for font Noto Serif etc.
 bannerFont = "fonts/exampleFont" # custom your own font for the title.
+postDateFormat = "2006-1-2" # override custom date format posts.
 
 [menu]
 # Shown in the side menu.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,6 +28,7 @@ favicon = "img/favicon-32x32.png"
 fuse = true # for searchbox. "JSON" must added to output contents. See [outputs].
 math = true # for introducing $KaTEX$
 useChineseFonts = true 
+postDateFormat = "2006-1-2"
 
 [menu]
 # Shown in the side menu.

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -13,7 +13,7 @@
 	{{- partial "tags.html" . -}}
 	<time class="text-eucalyptus-500 md:text-right md:flex-grow font-light pl-4"
 		datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-		{{- .Date.Format "2006-1-2 15:04" -}}
+		{{- .Date.Format (.Site.Params.PostDateFormat | default "2006-1-2 15:04") -}}
 	</time>
 </div>
 {{ partial "toc.html" . }}

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -17,7 +17,7 @@
 		{{- partial "tags.html" . -}}
 		<time class="text-eucalyptus-500 md:text-right md:flex-grow font-light"
 			datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-			{{- .Date.Format "2006-1-2 15:04" -}}
+			{{- .Date.Format (.Site.Params.PostDateFormat | default "2006-1-2 15:04") -}}
 		</time>
 	</div>
 </div>


### PR DESCRIPTION
This adds `postDateFormat` as an optional parameter to override the default format of dates for posts. The default includes time which in the example site, and my own site, is always `00:00`.

I have two questions with this change:

1. Do you prefer a different name than `postDateFormat`
1. Should this also affect the date format in `list.xml` -- I believe this is only for RSS which I don't personally care about, but happy to change it there if you prefer.

This does not modify the date format for `list.html` as it by default splits by year and only includes month-day for the post already.